### PR TITLE
Fix GitHub Pages build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "dev": "NODE_ENV=development tsx server/index.ts",
-    "build:static": "rm -rf dist && mkdir -p dist/public && cd client && npm ci && npm run build && cp -R dist/* ../dist/public/",
+    "build:static": "node scripts/build-static.js",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary
- remove duplicate `dev` script
- simplify `build:static` to call `scripts/build-static.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686579b7c828832fad052177a2235421