### PR TITLE
fix API base URL on gh-pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import path from "path";
 export default defineConfig({
   base: '/thecueroom/',    // ← add this line
   root: "client",
+  envDir: path.resolve(__dirname),
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- load env vars from the repo root so VITE_API_BASE_URL is injected during builds

## Testing
- `npm run build:client` *(fails: Cannot find module `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_686741c87734832f93a40d7cf79d2002