### PR TITLE
Fix image 404s

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
-    <link rel="icon" type="image/x-icon" href="/attached_assets/Icon_1751081882323.ico" />
+    <link
+      rel="icon"
+      type="image/png"
+      href="images/img-logo128x128_1751081882323.png"
+    />
     <title>TheCueRoom - Underground Music Community</title>
     <meta name="description" content="Verified community for India's underground techno and house music artists and DJs. Connect, share, and discover in the underground scene." />
 

--- a/client/src/components/ui/logo.tsx
+++ b/client/src/components/ui/logo.tsx
@@ -15,10 +15,15 @@ export function Logo({
   animationType = 'glow'
 }: LogoProps) {
   const getLogoSrc = () => {
+    const basePath = (import.meta.env.VITE_BASE_PATH || '/') as string;
+    const prefix = basePath.endsWith('/') ? basePath : `${basePath}/`;
     switch (size) {
-      case 'sm': return "/images/img-logo128x128_1751081882323.png";
-      case 'lg': return "/images/img-logo512x512_1751081882323.png";
-      default: return "/images/img-logo256x256_1751081882323.png";
+      case 'sm':
+        return `${prefix}images/img-logo128x128_1751081882323.png`;
+      case 'lg':
+        return `${prefix}images/img-logo512x512_1751081882323.png`;
+      default:
+        return `${prefix}images/img-logo256x256_1751081882323.png`;
     }
   };
 


### PR DESCRIPTION
## Summary
- use base-aware paths for logo component
- change favicon link to an existing image

## Testing
- `npm run build:client` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c02d8f290832f8faf1400a09171ff