### PR TITLE
Fix client entry script path

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -31,8 +31,7 @@
     />
 
     <!-- Vite will rewrite these at build time -->
-    <link rel="stylesheet" href="./assets/index.css" />
-    <script type="module" src="./assets/index.js"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- point client/index.html to the Vite entry script

## Testing
- `npm run build` *(fails: cannot find cross-env and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c094c8770832f90903d773bfaa82a