### PR TITLE
Add password reset email

### DIFF
--- a/server/replitAuth.ts
+++ b/server/replitAuth.ts
@@ -1,5 +1,5 @@
 import * as client from "openid-client";
-import { Strategy, type VerifyFunction } from "openid-client/passport";
+import { Strategy, type VerifyFunction } from "openid-client/build/passport.js";
 
 import passport from "passport";
 import session from "express-session";
@@ -78,7 +78,7 @@ export async function setupAuth(app: Express) {
     tokens: client.TokenEndpointResponse & client.TokenEndpointResponseHelpers,
     verified: passport.AuthenticateCallback
   ) => {
-    const user = {};
+    const user: Express.User = {} as Express.User;
     updateUserSession(user, tokens);
     await upsertUser(tokens.claims());
     verified(null, user);

--- a/server/services/emailService.ts
+++ b/server/services/emailService.ts
@@ -108,6 +108,32 @@ export class EmailService {
     return result.success;
   }
 
+  async sendResetLink(email: string, token: string): Promise<boolean> {
+    const baseUrl = process.env.SITE_URL || 'http://localhost:5000';
+    const resetUrl = `${baseUrl}/reset-password?token=${token}&email=${encodeURIComponent(email)}`;
+
+    const html = `
+      <div style="font-family: sans-serif; line-height:1.4;">
+        <h1>Password Reset</h1>
+        <p>Click below to reset your password:</p>
+        <p><a href="${resetUrl}">Reset Password</a></p>
+        <p>If that doesn’t work, paste this URL in your browser:</p>
+        <p>${resetUrl}</p>
+      </div>
+    `;
+
+    const text = `Reset your password: ${resetUrl}`;
+
+    const result = await this.sendEmail({
+      to: email,
+      subject: 'Reset your TheCueRoom password',
+      html,
+      text,
+    });
+
+    return result.success;
+  }
+
   /** Simple config check */
   async testConnection(): Promise<{ success: boolean; provider: 'smtp'; error?: string }> {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -64,7 +64,7 @@ import {
   type InsertSupportTicket,
 } from "@shared/schema";
 import { db } from "./db";
-import { eq, desc, and, sql, inArray } from "drizzle-orm";
+import { eq, desc, and, sql, inArray, lt } from "drizzle-orm";
 
 export interface IStorage {
   // User operations (custom auth)

--- a/server/vercel-adapter.ts
+++ b/server/vercel-adapter.ts
@@ -80,7 +80,7 @@ app.post('/api/posts', async (req, res) => {
 // Gigs endpoints
 app.get('/api/gigs', async (req, res) => {
   try {
-    const gigs = await storage.getAllGigs();
+    const gigs = await storage.getGigs();
     res.json(gigs);
   } catch (error) {
     console.error('Error fetching gigs:', error);
@@ -91,7 +91,7 @@ app.get('/api/gigs', async (req, res) => {
 // News endpoints
 app.get('/api/news', async (req, res) => {
   try {
-    const news = await storage.getAllNews();
+    const news = await storage.getNewsArticles();
     res.json(news);
   } catch (error) {
     console.error('Error fetching news:', error);
@@ -102,7 +102,7 @@ app.get('/api/news', async (req, res) => {
 // Playlists endpoints
 app.get('/api/playlists', async (req, res) => {
   try {
-    const playlists = await storage.getAllPlaylists();
+    const playlists = await storage.getPlaylists();
     res.json(playlists);
   } catch (error) {
     console.error('Error fetching playlists:', error);

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,7 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger } from "vite";
+import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
@@ -20,7 +20,7 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,
@@ -46,7 +46,7 @@ export async function setupVite(app: Express, server: Server) {
 
     try {
       const clientTemplate = path.resolve(
-        import.meta.dirname,
+        __dirname,
         "..",
         "client",
         "index.html",


### PR DESCRIPTION
## Summary
- implement `sendResetLink` in `EmailService`
- use `openid-client` build path for Replit auth
- type verification callback correctly
- adjust vercel adapter to new storage APIs
- switch Vite server to typed options and use `__dirname`
- include `lt` operator import for cleanup

## Testing
- `npx tsc -p tsconfig.server.json` *(fails: Property 'firstName' does not exist on type '{}', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686e696e5d78832fa8c228d08c6b0315