### PR TITLE
Fix production entry path

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preview": "cross-env VITE_BASE_PATH=/thecueroom/ vite preview",
     "build:static": "npm run build:client && npm run postbuild:client",
     "build": "npm run build:server && npm run build:client && npm run postbuild:client",
-    "start": "NODE_ENV=production node dist/server/index.js",
+    "start": "NODE_ENV=production node dist/server/server/index.js",
     "dev": "concurrently \"tsc -p tsconfig.server.json --watch\" \"vite\"",
     "check": "tsc",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary
- fix Node entry path for production start script

## Testing
- `npm run build:server`
- `npx vitest run tests/unit/auth.test.ts --reporter=verbose` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_686e71ec7528832f910770f2c1346195