### PR TITLE
Fix server start path

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preview": "cross-env VITE_BASE_PATH=/thecueroom/ vite preview",
     "build:static": "npm run build:client && npm run postbuild:client",
     "build": "npm run build:server && npm run build:client && npm run postbuild:client",
-    "start": "NODE_ENV=production node /dist/server/index.js",
+    "start": "NODE_ENV=production node dist/server/server/index.js",
     "dev": "concurrently \"tsc -p tsconfig.server.json --watch\" \"vite\"",
     "check": "tsc",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary
- correct the start script to use a relative path to the built server entry

## Testing
- `npm run build:server`

------
https://chatgpt.com/codex/tasks/task_e_686e93fd5638832fae81506fe60ca8a6