### PR TITLE
Fix base path for GitHub Pages

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,6 @@
 CLIENT_URL=https://dejayillegal.github.io/
 
 # Baked into the client bundle by Vite:
-VITE_BASE_PATH=/
+VITE_BASE_PATH=/thecueroom/
 VITE_API_BASE_URL=https://thecueroom-api.onrender.com
-
 PGSSLMODE=requireDATABASE_URL=postgresql://thecueroom_db_owner:npg_2PNEIo6kYFKq@ep-odd-field-a91x4yml-pooler.gwc.azure.neon.tech/thecueroom_db?sslmode=require&channel_binding=require

--- a/.env.production
+++ b/.env.production
@@ -4,8 +4,7 @@ SITE_URL=https://thecueroom.xyz
 API_URL=https://api.thecueroom.xyz
 
 # Baked into the client bundle by Vite:
-VITE_BASE_PATH=/
+VITE_BASE_PATH=/thecueroom/
 VITE_API_BASE_URL=https://thecueroom-api.onrender.com
 
-CLIENT_URL=https://dejayillegal.github.io/
-DATABASE_URL=postgresql://thecueroom_db_owner:npg_2PNEIo6kYFKq@ep-odd-field-a91x4yml-pooler.gwc.azure.neon.tech/thecueroom_db?sslmode=require&channel_binding=require
+CLIENT_URL=https://dejayillegal.github.io/DATABASE_URL=postgresql://thecueroom_db_owner:npg_2PNEIo6kYFKq@ep-odd-field-a91x4yml-pooler.gwc.azure.neon.tech/thecueroom_db?sslmode=require&channel_binding=require

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,7 +23,7 @@ jobs:
           npm install
           npm run build:static
         env:
-          VITE_BASE_PATH: /
+          VITE_BASE_PATH: /thecueroom/
           VITE_API_BASE_URL: https://thecueroom-api.onrender.com
 
       - name: Upload Pages Artifact

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "homepage": "https://dejayillegal.github.io/",
+  "homepage": "https://dejayillegal.github.io/thecueroom/",
   "license": "MIT",
   "scripts": {
     "build:shared": "tsc -p tsconfig.shared.json",


### PR DESCRIPTION
## Summary
- update GitHub Pages workflow to use `/thecueroom/` base path
- set the same base path in `.env` and `.env.production`
- set repository homepage accordingly

## Testing
- `node run-tests.js` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686e9b296510832f9d1a7289964e5062