### PR TITLE
Add troubleshooting guide for Vite plugin error

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,23 @@
+# Troubleshooting
+
+## Missing `@vitejs/plugin-react` during build
+If the build fails with an error like:
+
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@vitejs/plugin-react'
+```
+
+it usually means the dev dependencies were skipped or installed for a different platform.
+Clean the install and reinstall with dev dependencies enabled:
+
+```bash
+rm -rf node_modules package-lock.json
+NPM_CONFIG_PRODUCTION=false npm install
+```
+
+This fetches the correct optional binaries for your OS (e.g., `@rollup/rollup-linux-x64-gnu`).
+After reinstalling, run the build again:
+
+```bash
+npm run build
+```


### PR DESCRIPTION
## Summary
- document how to fix missing `@vitejs/plugin-react` error

## Testing
- `npm run build:shared`
- `npm run build:server`
- `npm run build:client` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686ed2ea23a0832fa34aa65a06296294