### PR TITLE
Fix vite build by moving react plugin to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "ws": "^8.18.0",
     "xml2js": "^0.6.2",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "@vitejs/plugin-react": "^4.3.2"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",
@@ -151,7 +152,6 @@
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@types/ws": "^8.5.13",
-    "@vitejs/plugin-react": "^4.3.2",
     "autoprefixer": "^10.4.20",
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
## Summary
- include `@vitejs/plugin-react` in `dependencies` so render build installs it

## Testing
- `npm run check` *(fails: multiple TypeScript errors)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6870694d39e0832f9fe5ffd683810e4c