### PR TITLE
Fix autoprefixer missing in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
     "xml2js": "^0.6.2",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0",
-    "@vitejs/plugin-react": "^4.3.2"
+    "@vitejs/plugin-react": "^4.3.2",
+    "autoprefixer": "^10.4.20"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",
@@ -152,7 +153,6 @@
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@types/ws": "^8.5.13",
-    "autoprefixer": "^10.4.20",
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",
     "dotenv": "^17.0.1",


### PR DESCRIPTION
## Summary
- move `autoprefixer` from devDependencies to dependencies so Vite build finds the plugin

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build:client` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68706ad331b0832fb66a7bd018f8614e