### PR TITLE
Fix start script path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postbuild:client": "cp dist/index.html dist/404.html",
     "build:static": "npm run build:client && npm run postbuild:client",
     "build": "npm run build:shared && npm run build:server && npm run build:static",
-    "start": "NODE_ENV=production node dist/server/server/index.js",
+    "start": "NODE_ENV=production node dist/server/index.js",
     "dev":      "concurrently \"tsc -p tsconfig.server.json --watch\" \"cross-env VITE_BASE_PATH=/ vite\"",
     "check":    "tsc",
     "db:push":   "drizzle-kit push",


### PR DESCRIPTION
## Summary
- fix server start path to use `dist/server/index.js`

## Testing
- `npm run build:server`
- `npm run check` *(fails: React/TS errors)*
- `npm start` *(fails: exports is not defined due to ESM/CJS mix)*

------
https://chatgpt.com/codex/tasks/task_e_68707100a768832f97c8800eebb819ff