### PR TITLE
Fix CORS for multiple origins

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -21,11 +21,25 @@ const app = express();
 // Strictly match your GitHub Pages origin here
 const clientOrigin = process.env.CLIENT_URL || 'https://dejayillegal.github.io';
 
-const corsOptions = {
-  origin: clientOrigin,
-  methods: ['GET','POST','PUT','DELETE','OPTIONS'],
-  allowedHeaders: ['Content-Type','Authorization'],
-  credentials: true as const,
+// Allow multiple frontend origins (GitHub Pages & custom domains)
+const allowedOrigins = [
+  clientOrigin,
+  'https://dejayillegal.github.io',
+  'https://thecueroom.xyz',
+  'https://www.thecueroom.xyz',
+];
+
+const corsOptions: cors.CorsOptions = {
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+  credentials: true,
 };
 
 // Preflight for ALL routes


### PR DESCRIPTION
## Summary
- allow multiple frontend domains in Express CORS setup

## Testing
- `node run-tests.js` *(fails: cannot find tests/load/performance-tests.yml)*
- `npx tsc -p tsconfig.server.json` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687669b05a24832fb8c743746b4ccfe8