### PR TITLE
Fix CORS origin config

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -30,16 +30,11 @@ const allowedOrigins = [
 ];
 
 const corsOptions: cors.CorsOptions = {
-  origin: (origin, callback) => {
-    if (!origin || allowedOrigins.includes(origin)) {
-      callback(null, true);
-    } else {
-      callback(new Error('Not allowed by CORS'));
-    }
-  },
+  origin: allowedOrigins,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization'],
   credentials: true,
+  optionsSuccessStatus: 200,
 };
 
 // Preflight for ALL routes


### PR DESCRIPTION
## Summary
- relax CORS origin check by using the list of allowed origins directly

## Testing
- `node run-tests.js` *(fails: ENOENT for `tests/load/performance-tests.yml`)*
- `npm run build:server` *(fails: TS errors in server code)*

------
https://chatgpt.com/codex/tasks/task_e_68767941611c832f9a33b7a3f0533a68