### PR TITLE
Fix CORS for GitHub Pages

### DIFF
--- a/server/vercel-adapter.ts
+++ b/server/vercel-adapter.ts
@@ -10,7 +10,11 @@ const app = express();
 
 // CORS configuration for production
 app.use(cors({
-  origin: ['https://thecueroom.xyz', 'https://www.thecueroom.xyz'],
+  origin: [
+    'https://thecueroom.xyz',
+    'https://www.thecueroom.xyz',
+    'https://dejayillegal.github.io'
+  ],
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'Cookie']


### PR DESCRIPTION
## Summary
- allow `https://dejayillegal.github.io` as an allowed origin in the production CORS config

## Testing
- `node run-tests.js` *(fails: ENOENT performance-tests.yml)*

------
https://chatgpt.com/codex/tasks/task_e_687689987be88329a54a5346907242f0