### PR TITLE
Adjust health check thresholds

### DIFF
--- a/server/utils/healthChecks.ts
+++ b/server/utils/healthChecks.ts
@@ -26,7 +26,12 @@ export async function checkDatabaseHealth(): Promise<HealthCheckResult> {
     
     return {
       service: 'database',
-      status: responseTime < 100 ? 'healthy' : responseTime < 500 ? 'degraded' : 'unhealthy',
+      status:
+        responseTime < 400
+          ? 'healthy'
+          : responseTime < 1000
+            ? 'degraded'
+            : 'unhealthy',
       responseTime,
       details: {
         provider: getServiceConfiguration().database.provider,


### PR DESCRIPTION
## Summary
- refine DB health check thresholds so typical response times count as healthy

## Testing
- `npm run check` *(fails: cannot find module declarations and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68768e9f98e883299d9238498ceaffb8