### PR TITLE
Fix CORS for login requests

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -30,7 +30,14 @@ const allowedOrigins = [
 ];
 
 const corsOptions: cors.CorsOptions = {
-  origin: allowedOrigins,
+  origin: (origin, callback) => {
+    if (!origin) return callback(null, true);
+    const normalized = origin.replace(/\/$/, '');
+    if (allowedOrigins.includes(normalized)) {
+      return callback(null, true);
+    }
+    return callback(new Error('Not allowed by CORS'));
+  },
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'Cookie'],
   credentials: true,

--- a/server/vercel-adapter.ts
+++ b/server/vercel-adapter.ts
@@ -9,15 +9,24 @@ import cors from 'cors';
 const app = express();
 
 // CORS configuration for production
+const allowedOrigins = [
+  'https://thecueroom.xyz',
+  'https://www.thecueroom.xyz',
+  'https://dejayillegal.github.io',
+];
+
 app.use(cors({
-  origin: [
-    'https://thecueroom.xyz',
-    'https://www.thecueroom.xyz',
-    'https://dejayillegal.github.io'
-  ],
+  origin: (origin, callback) => {
+    if (!origin) return callback(null, true);
+    const normalized = origin.replace(/\/$/, '');
+    if (allowedOrigins.includes(normalized)) {
+      return callback(null, true);
+    }
+    return callback(new Error('Not allowed by CORS'));
+  },
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'Cookie']
+  allowedHeaders: ['Content-Type', 'Authorization', 'Cookie'],
 }));
 
 app.use(express.json({ limit: '10mb' }));


### PR DESCRIPTION
## Summary
- handle trailing slashes when matching allowed origins
- apply same CORS logic in the Vercel adapter

## Testing
- `node run-tests.js` *(fails: Cannot find module `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_6876962193a08329adc73967aa25d63f