### PR TITLE
Improve auth password comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,8 +138,8 @@
     "ws": "^8.18.0",
     "xml2js": "^0.6.2",
     "zod": "^3.24.2",
-    "cross-env": "^7.0.3",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "cross-env": "^7.0.3"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",
@@ -150,6 +150,7 @@
     "@types/connect-pg-simple": "^7.0.3",
     "@types/express": "4.17.21",
     "@types/express-session": "^1.18.0",
+    "@types/module-alias": "^2.0.4",
     "@types/node": "^20.16.11",
     "@types/openid-client": "^3.1.6",
     "@types/passport": "^1.0.16",

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -24,11 +24,20 @@ export async function hashPassword(password: string): Promise<string> {
   return `${buf.toString("hex")}.${salt}`;
 }
 
-async function comparePasswords(supplied: string, stored: string): Promise<boolean> {
-  const [hashed, salt] = stored.split(".");
-  const hashedBuf = Buffer.from(hashed, "hex");
-  const suppliedBuf = (await scryptAsync(supplied, salt, 64)) as Buffer;
-  return timingSafeEqual(hashedBuf, suppliedBuf);
+export async function comparePasswords(
+  supplied: string,
+  stored: string
+): Promise<boolean> {
+  try {
+    const [hashed, salt] = stored.split('.');
+    if (!hashed || !salt) return false;
+    const hashedBuf = Buffer.from(hashed, 'hex');
+    const suppliedBuf = (await scryptAsync(supplied, salt, 64)) as Buffer;
+    return timingSafeEqual(hashedBuf, suppliedBuf);
+  } catch (err) {
+    console.error('Password comparison failed:', err);
+    return false;
+  }
 }
 
 /**

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -1,7 +1,7 @@
 import 'module-alias/register';
 import { describe, it, expect } from 'vitest';
 // Use built server module for stable imports during tests
-import { generateTemporaryPassword } from '../../dist/server/auth.js';
+import { generateTemporaryPassword, hashPassword, comparePasswords } from '../../dist/server/auth.js';
 
 function hasUpper(str: string) {
   return /[A-Z]/.test(str);
@@ -28,5 +28,18 @@ describe('generateTemporaryPassword', () => {
     expect(hasLower(pwd)).toBe(true);
     expect(hasDigit(pwd)).toBe(true);
     expect(hasSpecial(pwd)).toBe(true);
+  });
+});
+
+describe('password hashing and comparison', () => {
+  it('hashes and compares passwords correctly', async () => {
+    const hashed = await hashPassword('secret');
+    const result = await comparePasswords('secret', hashed);
+    expect(result).toBe(true);
+  });
+
+  it('returns false for invalid stored format', async () => {
+    const result = await comparePasswords('secret', 'invalid');
+    expect(result).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- export `comparePasswords` and make it resilient to malformed hashes
- test password hashing and comparison
- add `@types/module-alias` dev dependency to satisfy TS build
- move `cross-env` entry back to the end of dependencies

## Testing
- `npx vitest run --dir tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_68769cf6b5a483299885fa258a01753c