### PR TITLE
Fix esbuild install version mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
    },
   "dependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.44.2",
-    "@esbuild/linux-x64": "0.18.20",
+    "@esbuild/linux-x64": "0.19.12",
     "@anthropic-ai/sdk": "^0.37.0",
     "@hookform/resolvers": "^3.10.0",
     "@jridgewell/trace-mapping": "^0.3.25",


### PR DESCRIPTION
## Summary
- pin `@esbuild/linux-x64` to `0.19.12` so the binary matches `esbuild`

## Testing
- `npm run check` *(fails: cannot compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_687750cc4014832faf2a3f63d2894da3