### PR TITLE
Fix ESM export in shared schema

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -519,7 +519,7 @@ export const insertTrackSchema = z.object({
 }).passthrough();
 
 
-exports.insertModerationLogSchema = createInsertSchema(exports.moderationLogs);
+export const insertModerationLogSchema = createInsertSchema(moderationLogs);
 
 export const insertCuratedPlaylistSchema = createInsertSchema(curatedPlaylists);
 


### PR DESCRIPTION
## Summary
- fix CommonJS export in `shared/schema.ts` so Drizzle pushes work

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68778ef2fa44832fb071e3a4c7939b9d