### PR TITLE
Fix session cookie for cross-site deployment

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -112,7 +112,11 @@ export function setupAuth(app: Express): void {
     secret: process.env.SESSION_SECRET || 'change-this',
     resave: false,
     saveUninitialized: false,
-    cookie: { secure: process.env.NODE_ENV === 'production', maxAge: 7 * 24 * 60 * 60 * 1000 }
+    cookie: {
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    }
   };
 
   app.set("trust proxy", 1);

--- a/server/replitAuth.ts
+++ b/server/replitAuth.ts
@@ -39,6 +39,7 @@ export function getSession() {
     cookie: {
       httpOnly: true,
       secure: true,
+      sameSite: 'none',
       maxAge: sessionTtl,
     },
   });


### PR DESCRIPTION
## Summary
- update Express session settings to use `SameSite=None`
- ensure Replit OAuth flow also sets `SameSite=None`

## Testing
- `node run-tests.js` *(fails: ENOENT: no such file or directory, open 'tests/load/performance-tests.yml')*

------
https://chatgpt.com/codex/tasks/task_e_6877a004bee0832f86af692b0cd42ec1