### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -4,7 +4,7 @@ SITE_URL=https://thecueroom.xyz
 API_URL=https://api.thecueroom.xyz
 
 # Baked into the client bundle by Vite:
-VITE_BASE_PATH=/
+VITE_BASE_PATH=/thecueroom/
 VITE_API_BASE_URL=https://thecueroom-api.onrender.com
 CLIENT_URL=https://dejayillegal.github.io/
 

--- a/client/public/404.html
+++ b/client/public/404.html
@@ -6,17 +6,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Page Not Found</title>
   <!-- Immediately redirect back to your base path -->
-  <meta http-equiv="refresh" content="0;url=%BASE_PATH%" />
   <script>
-    // Fallback JS redirect for browsers that ignore the meta tag:
-    window.location.replace((import.meta.env.VITE_BASE_PATH || "/") + window.location.pathname);
+    const base = import.meta.env.VITE_BASE_PATH || "/";
+    const prefix = base.endsWith("/") ? base : base + "/";
+    // Redirect preserving the original path for SPA routing
+    window.location.replace(prefix + window.location.pathname);
   </script>
 </head>
 <body>
   <h1>404 – Page Not Found</h1>
   <p>
     Redirecting you back to
-    <a href="%BASE_PATH%">home</a>…
+    <a href="javascript:void 0" onclick="history.back()">home</a>…
   </p>
 </body>
 </html>

--- a/scripts/build-dev.js
+++ b/scripts/build-dev.js
@@ -47,7 +47,7 @@ console.log('   ✓ Created .nojekyll file');
 
 // Step 6: Update base href in HTML files
 console.log('5. Updating base paths...');
-const htmlFiles = ['dist/ndex.html', 'dist/404.html'];
+const htmlFiles = ['dist/index.html', 'dist/404.html'];
 htmlFiles.forEach(file => {
   if (fs.existsSync(file)) {
     let content = fs.readFileSync(file, 'utf8');


### PR DESCRIPTION
## Summary
- set correct base path for production build
- improve SPA redirect logic in `404.html`
- fix build script typo for base path injection

## Testing
- `npm run check` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877be4ae6cc832fb7d57eb5c3e425d5