### PR TITLE
Fix session persistence after login

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -192,6 +192,16 @@ export function setupAuth(app: Express): void {
     })(req, res, next)
   );
 
+  // Current user
+  app.get("/api/auth/user", (req, res) => {
+    if (!req.isAuthenticated() || !req.user) {
+      return res.status(401).json({ message: "Unauthorized" });
+    }
+
+    const { password, securityQuestion, securityAnswer, verificationToken, resetToken, resetTokenExpiry, ...safeUser } = req.user as any;
+    res.json(safeUser);
+  });
+
   // Logout
   app.post("/api/auth/logout", (req, res, next) => {
     req.logout(err => {


### PR DESCRIPTION
## Summary
- return current user from `/api/auth/user`

## Testing
- `node run-tests.js` *(fails: ENOENT: no such file or directory, open 'tests/load/performance-tests.yml')*

------
https://chatgpt.com/codex/tasks/task_e_6877c3382d1c832fb3cf797950af337b