### PR TITLE
Fix 404 home link

### DIFF
--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -96,7 +96,7 @@ export default function NotFound() {
 
         {/* Action buttons */}
         <div className="flex flex-col sm:flex-row gap-4 justify-center pt-4">
-          <Link href={homeHref}>
+          <Link href="/">
             <Button className="gap-2 bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 border-0">
               <Home className="h-4 w-4" />
               Back to The Room


### PR DESCRIPTION
## Summary
- update NotFound page home link

## Testing
- `npm run check` *(fails: Property 'mixcloudUrl' does not exist on type 'Response', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6877ca29be04832fb9558e9abf2c5586