### PR TITLE
Fix flash redirect on refresh

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import TheCueRoomBot from "@/components/thecueroom-bot";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { AnimationProvider } from "@/contexts/AnimationContext";
 import Landing from "@/pages/landing";
+import LoadingScreen from "@/components/layout/loading-screen";
 import Home from "@/pages/home";
 import Community from "@/pages/community";
 import Admin from "@/pages/admin";
@@ -32,7 +33,7 @@ function Router() {
   // Create a component wrapper that handles authentication-based rendering
   const AuthenticatedRoute = ({ component: Component, fallback: Fallback = Landing }: { component: React.ComponentType, fallback?: React.ComponentType }) => {
     if (isLoading) {
-      return <Landing />; // Show landing during loading
+      return <LoadingScreen />; // Avoid landing flash during auth check
     }
     return isAuthenticated ? <Component /> : <Fallback />;
   };

--- a/client/src/components/layout/loading-screen.tsx
+++ b/client/src/components/layout/loading-screen.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default function LoadingScreen() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="loading-pulse">
+        <div className="w-8 h-8 bg-primary rounded-full flex items-center justify-center">
+          <div className="w-4 h-4 bg-primary-foreground rounded-full animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `LoadingScreen` component with pulse animation
- use `LoadingScreen` while checking auth instead of Landing

## Testing
- `node run-tests.js` *(fails: ENOENT tests/load/performance-tests.yml)*

------
https://chatgpt.com/codex/tasks/task_e_6877cbc4d818832fa887e3c59b179a0d