### PR TITLE
Persist user session to prevent landing flashes

### DIFF
--- a/client/src/components/auth/auth-modal.tsx
+++ b/client/src/components/auth/auth-modal.tsx
@@ -25,6 +25,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest, queryClient } from "@/lib/queryClient";
+import { safeStorage } from "@/lib/safe-dom";
 import { Eye, EyeOff, Music, Mail, HelpCircle, UserCog, ArrowLeft, Check, X, Sparkles } from "lucide-react";
 import { Logo } from "@/components/ui/logo";
 import ForcePasswordChange from "./force-password-change";
@@ -275,8 +276,9 @@ export default function AuthModal({ isOpen, onClose }: AuthModalProps) {
         setForcePasswordChange({ email: data.email });
         return;
       }
-      
+
       queryClient.setQueryData(["/api/auth/user"], data);
+      safeStorage.setItem("tcr-user", JSON.stringify(data));
       toast({
         title: "Welcome back!",
         description: "You've successfully logged in to TheCueRoom.",

--- a/client/src/components/layout/navbar.tsx
+++ b/client/src/components/layout/navbar.tsx
@@ -35,6 +35,7 @@ import {
 } from "lucide-react";
 import { Logo } from "@/components/ui/logo";
 import { apiRequest } from "@/lib/queryClient";
+import { safeStorage } from "@/lib/safe-dom";
 
 export default function Navbar() {
   const [location, navigate] = useLocation();
@@ -161,9 +162,11 @@ export default function Navbar() {
                       await apiRequest('POST', '/api/auth/logout');
                       queryClient.setQueryData(['/api/auth/user'], null);
                       queryClient.invalidateQueries({ queryKey: ['/api/auth/user'] });
+                      safeStorage.removeItem('tcr-user');
                     } catch (error) {
                       console.error('Logout error:', error);
                       queryClient.setQueryData(['/api/auth/user'], null);
+                      safeStorage.removeItem('tcr-user');
                     } finally {
                       window.location.href = '/';
                     }

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,15 +1,36 @@
 import { useQuery } from "@tanstack/react-query";
 import type { User } from "@shared/schema";
+import { safeStorage } from "@/lib/safe-dom";
+
+const STORAGE_KEY = "tcr-user";
 
 export function useAuth() {
-  const { data: user, isLoading, error } = useQuery<User | null>({
+  const {
+    data,
+    isLoading: queryLoading,
+    error,
+  } = useQuery<User | null>({
     queryKey: ["/api/auth/user"],
     retry: false,
+    initialData: () => {
+      const cached = safeStorage.getItem(STORAGE_KEY);
+      return cached ? (JSON.parse(cached) as User) : null;
+    },
+    onSuccess: (u) => {
+      if (u) {
+        safeStorage.setItem(STORAGE_KEY, JSON.stringify(u));
+      } else {
+        safeStorage.removeItem(STORAGE_KEY);
+      }
+    },
   });
+
+  const cached = safeStorage.getItem(STORAGE_KEY);
+  const user = data ?? (cached ? (JSON.parse(cached) as User) : null);
 
   return {
     user,
-    isLoading,
+    isLoading: queryLoading || (!!error && !!user),
     isAuthenticated: !!user,
     error,
   };

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -3,6 +3,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
+import { safeStorage } from "@/lib/safe-dom";
 import UniversalHeader from "@/components/layout/universal-header";
 import { Footer } from "@/components/layout/footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -74,6 +75,7 @@ export default function Profile() {
     },
     onSuccess: (updatedUser) => {
       queryClient.setQueryData(['/api/auth/user'], updatedUser);
+      safeStorage.setItem('tcr-user', JSON.stringify(updatedUser));
       setIsEditing(false);
       toast({
         title: "Profile Updated",


### PR DESCRIPTION
## Summary
- cache the authenticated user in `localStorage`
- update login, logout, and profile update flows to sync cache
- make `useAuth` read from cached data on errors

## Testing
- `node run-tests.js` *(fails: ENOENT performance-tests.yml)*

------
https://chatgpt.com/codex/tasks/task_e_6877d5637f70832f91e3e48b9c1d77d2