### PR TITLE
Fix GitHub Pages redirect loop

### DIFF
--- a/client/public/404.html
+++ b/client/public/404.html
@@ -11,8 +11,14 @@
     const segments = window.location.pathname.split('/').filter(Boolean);
     const base = segments.length ? `/${segments[0]}/` : '/';
     const rest = segments.slice(1).join('/');
-    // Redirect preserving the path for SPA routing without double slashes
-    window.location.replace(base + rest);
+
+    // Store the requested path so the SPA can restore it after redirecting
+    if (rest) {
+      sessionStorage.setItem('redirect-path', '/' + rest);
+    }
+
+    // Redirect to the root index page
+    window.location.replace(base);
   </script>
 </head>
 <body>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,7 +3,7 @@
 // client/src/main.tsx
 import { createRoot } from "react-dom/client";
 import { Router } from "wouter";
-import { getRouterBase } from "./lib/router-config";
+import { getRouterBase, getBasePath } from "./lib/router-config";
 import App from "./App";
 import "./index.css";
 
@@ -14,6 +14,14 @@ const root = createRoot(container);
 
 // Determine base path without trailing slash for wouter routing
 const base = getRouterBase();
+
+// If redirected from 404.html, restore the original path
+const savedPath = sessionStorage.getItem('redirect-path');
+if (savedPath) {
+  sessionStorage.removeItem('redirect-path');
+  const basePath = getBasePath().replace(/\/$/, '');
+  history.replaceState(null, '', basePath + savedPath);
+}
 
 root.render(
   <Router base={base}>


### PR DESCRIPTION
## Summary
- update custom 404.html to save the path and redirect to index
- restore path on load so SPA routes work

## Testing
- `npm run build:static` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e31a1fb0832f88d832a659459e05