### PR TITLE
Fix navigation base paths and feed ID encoding

### DIFF
--- a/client/src/components/navigation/main-navigation.tsx
+++ b/client/src/components/navigation/main-navigation.tsx
@@ -78,6 +78,8 @@ interface MainNavigationProps {
 export default function MainNavigation({ className }: MainNavigationProps) {
   const [location] = useLocation();
   const [hoveredCategory, setHoveredCategory] = useState<string | null>(null);
+  const basePath = (import.meta.env.VITE_BASE_PATH || '/') as string;
+  const prefix = basePath === '/' ? '' : basePath.replace(/\/$/, '');
 
   // Determine active category based on current location
   const getActiveCategory = () => {
@@ -108,7 +110,7 @@ export default function MainNavigation({ className }: MainNavigationProps) {
           const isHovered = hoveredCategory === category.id;
 
           return (
-            <Link key={category.id} href={category.href}>
+            <Link key={category.id} href={`${prefix}${category.href}`}>
               <Button
                 variant={isActive ? "default" : "ghost"}
                 size="lg"

--- a/client/src/services/feedService.ts
+++ b/client/src/services/feedService.ts
@@ -242,7 +242,10 @@ class FeedService {
     // Create unique ID from title and source
     const title = item.title || '';
     const link = item.link || '';
-    return btoa(`${source}-${title}-${link}`).replace(/[^a-zA-Z0-9]/g, '').slice(0, 16);
+    const combined = `${source}-${title}-${link}`;
+    // Encode to base64 safely for UTF-8 strings
+    const encoded = btoa(unescape(encodeURIComponent(combined)));
+    return encoded.replace(/[^a-zA-Z0-9]/g, '').slice(0, 16);
   }
 
   private extractTags(content: string, title: string): string[] {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2419,6 +2419,7 @@ Make it engaging and authentic to underground music culture. Respond with only a
 
   // RSS Feed Proxy for CORS handling
   app.get('/api/feeds/rss', async (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
     try {
       const { url } = req.query;
       


### PR DESCRIPTION
## Summary
- prefix navigation links with `VITE_BASE_PATH` so GitHub Pages routes work
- avoid btoa errors for non‑Latin titles when generating feed ids
- always send CORS headers from RSS proxy

## Testing
- `npm run build` *(fails: server TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877e48d5380832f9772f5b15a01debc