### PR TITLE
Fix CORS header for RSS proxy

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2417,9 +2417,9 @@ Make it engaging and authentic to underground music culture. Respond with only a
     }
   });
 
-  // RSS Feed Proxy for CORS handling
+  // RSS Feed Proxy
+  // CORS headers are applied by the global middleware in `server/index.ts`
   app.get('/api/feeds/rss', async (req, res) => {
-    res.setHeader('Access-Control-Allow-Origin', '*');
     try {
       const { url } = req.query;
       


### PR DESCRIPTION
## Summary
- remove per-route wildcard CORS header
- rely on global CORS middleware

## Testing
- `node run-tests.js` *(fails: ENOENT tests/load/performance-tests.yml)*

------
https://chatgpt.com/codex/tasks/task_e_6877f00b55b8832fbd71bb1fdfa61c6d