### PR TITLE
Fix logout redirect to landing page

### DIFF
--- a/client/src/components/layout/navbar.tsx
+++ b/client/src/components/layout/navbar.tsx
@@ -36,6 +36,7 @@ import {
 import { Logo } from "@/components/ui/logo";
 import { apiRequest } from "@/lib/queryClient";
 import { safeStorage } from "@/lib/safe-dom";
+import { getBasePath } from "@/lib/router-config";
 
 export default function Navbar() {
   const [location, navigate] = useLocation();
@@ -168,7 +169,7 @@ export default function Navbar() {
                       queryClient.setQueryData(['/api/auth/user'], null);
                       safeStorage.removeItem('tcr-user');
                     } finally {
-                      window.location.href = '/';
+                      window.location.href = getBasePath();
                     }
                   }}
                 >

--- a/client/src/components/layout/universal-header.tsx
+++ b/client/src/components/layout/universal-header.tsx
@@ -20,6 +20,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { apiRequest } from "@/lib/queryClient";
+import { safeStorage } from "@/lib/safe-dom";
 import {
   Home,
   Search,
@@ -38,6 +39,7 @@ import {
 } from "lucide-react";
 import { Logo } from "@/components/ui/logo";
 import { cn } from "@/lib/utils";
+import { getBasePath } from "@/lib/router-config";
 
 // Navigation categories
 const categories = [
@@ -166,8 +168,15 @@ export default function UniversalHeader({ className }: UniversalHeaderProps) {
                       onClick={async () => {
                         try {
                           await apiRequest('POST', '/api/auth/logout');
+                          queryClient.setQueryData(['/api/auth/user'], null);
+                          queryClient.invalidateQueries({ queryKey: ['/api/auth/user'] });
+                          safeStorage.removeItem('tcr-user');
+                        } catch (error) {
+                          console.error('Logout error:', error);
+                          queryClient.setQueryData(['/api/auth/user'], null);
+                          safeStorage.removeItem('tcr-user');
                         } finally {
-                          window.location.href = '/';
+                          window.location.href = getBasePath();
                         }
                       }}
                     >
@@ -252,8 +261,15 @@ export default function UniversalHeader({ className }: UniversalHeaderProps) {
                         onClick={async () => {
                           try {
                             await apiRequest('POST', '/api/auth/logout');
+                            queryClient.setQueryData(['/api/auth/user'], null);
+                            queryClient.invalidateQueries({ queryKey: ['/api/auth/user'] });
+                            safeStorage.removeItem('tcr-user');
+                          } catch (error) {
+                            console.error('Logout error:', error);
+                            queryClient.setQueryData(['/api/auth/user'], null);
+                            safeStorage.removeItem('tcr-user');
                           } finally {
-                            window.location.href = '/';
+                          window.location.href = getBasePath();
                           }
                         }}
                         className="flex items-center space-x-3 px-4 py-3 hover:bg-gray-800 text-gray-300 hover:text-white rounded-lg mx-2 cursor-pointer"

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -5,6 +5,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { safeStorage } from "@/lib/safe-dom";
+import { getBasePath } from "@/lib/router-config";
 import UniversalHeader from "@/components/layout/universal-header";
 import { Footer } from "@/components/layout/footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -810,8 +811,15 @@ export default function Profile() {
                 onClick={async () => {
                   try {
                     await apiRequest('POST', '/api/auth/logout');
+                    queryClient.setQueryData(['/api/auth/user'], null);
+                    queryClient.invalidateQueries({ queryKey: ['/api/auth/user'] });
+                    safeStorage.removeItem('tcr-user');
+                  } catch (error) {
+                    console.error('Logout error:', error);
+                    queryClient.setQueryData(['/api/auth/user'], null);
+                    safeStorage.removeItem('tcr-user');
                   } finally {
-                    window.location.href = '/';
+                    window.location.href = getBasePath();
                   }
                 }}
               >


### PR DESCRIPTION
## Summary
- use `getBasePath` when redirecting after logout
- clear auth caches on logout

## Testing
- `npm run check` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877f58adfa88329bbe828b2c8aba6fe