### PR TITLE
Improve feed fetching and gig submission

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -751,6 +751,7 @@ export class DatabaseStorage implements IStorage {
     return await db
       .select()
       .from(gigs)
+      .where(sql`LOWER(${gigs.location}) LIKE '%india%' OR LOWER(${gigs.location}) LIKE '%bangalore%'`)
       .orderBy(desc(gigs.date))
       .limit(limit)
       .offset(offset);
@@ -760,7 +761,7 @@ export class DatabaseStorage implements IStorage {
     return await db
       .select()
       .from(gigs)
-      .where(and(eq(gigs.isActive, true), sql`${gigs.date} >= NOW()`))
+      .where(and(eq(gigs.isActive, true), sql`${gigs.date} >= NOW()`, sql`(LOWER(${gigs.location}) LIKE '%india%' OR LOWER(${gigs.location}) LIKE '%bangalore%')`))
       .orderBy(gigs.date);
   }
 


### PR DESCRIPTION
## Summary
- speed up RSS feed fetching by limiting concurrency and skipping failed feeds
- retry RSS feeds that fail in the background
- only return gigs located in India
- allow users to submit gigs with validation for genre and flyer file

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build:shared`
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_687819b67fcc832988126a721e2a09a4