### PR TITLE
Add more guide feeds and gig submission improvements

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -26,6 +26,7 @@ import Contact from "@/pages/contact";
 import Privacy from "@/pages/privacy";
 import Terms from "@/pages/terms";
 import NotFound from "@/pages/not-found";
+import SubmitGig from "@/pages/submit-gig";
 
 function Router() {
   const { isAuthenticated, isLoading } = useAuth();
@@ -52,6 +53,7 @@ function Router() {
       <Route path="/profile" component={() => <AuthenticatedRoute component={Profile} />} />
       <Route path="/memes" component={() => <AuthenticatedRoute component={Memes} />} />
       <Route path="/gigs" component={() => <AuthenticatedRoute component={Gigs} />} />
+      <Route path="/submit-gig" component={() => <AuthenticatedRoute component={SubmitGig} />} />
       <Route path="/news" component={() => <AuthenticatedRoute component={News} />} />
       <Route path="/playlists" component={() => <AuthenticatedRoute component={Playlists} />} />
       <Route path="/music-platforms" component={() => <AuthenticatedRoute component={MusicPlatforms} />} />

--- a/client/src/components/admin/admin-panel.tsx
+++ b/client/src/components/admin/admin-panel.tsx
@@ -248,6 +248,20 @@ export default function AdminPanel() {
     },
   });
 
+  const approveGigMutation = useMutation({
+    mutationFn: async (gigId: number) => {
+      const res = await apiRequest('PATCH', `/api/gigs/${gigId}`, { isActive: true });
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/gigs'] });
+      toast({ title: 'Gig approved', description: 'Gig is now visible to users.' });
+    },
+    onError: () => {
+      toast({ title: 'Failed to approve gig', variant: 'destructive' });
+    }
+  });
+
   const handleDeleteUser = (userId: string) => {
     if (window.confirm("Are you sure you want to permanently delete this user? This action cannot be undone.")) {
       deleteUserMutation.mutate(userId);
@@ -594,6 +608,11 @@ export default function AdminPanel() {
                     </div>
                   </div>
                   <div className="flex items-center space-x-2">
+                    {!gig.isActive && (
+                      <Button size="sm" onClick={() => approveGigMutation.mutate(gig.id)}>
+                        Approve
+                      </Button>
+                    )}
                     <Button size="sm" variant="outline">Edit</Button>
                     <Button size="sm" variant="destructive">
                       <Trash2 className="h-3 w-3" />

--- a/client/src/pages/submit-gig.tsx
+++ b/client/src/pages/submit-gig.tsx
@@ -1,0 +1,189 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import UniversalHeader from "@/components/layout/universal-header";
+import { Footer } from "@/components/layout/footer";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { useToast } from "@/hooks/use-toast";
+
+const gigSchema = z.object({
+  title: z.string().min(3),
+  description: z.string().min(10),
+  venue: z.string().min(2),
+  location: z.string().min(2),
+  date: z.string(),
+  ticketUrl: z.string().url().optional(),
+  imageUrl: z.string().url().optional(),
+  genre: z.string().min(2),
+});
+
+type GigData = z.infer<typeof gigSchema>;
+
+export default function SubmitGig() {
+  const { toast } = useToast();
+  const form = useForm<GigData>({
+    resolver: zodResolver(gigSchema),
+    defaultValues: {
+      title: "",
+      description: "",
+      venue: "",
+      location: "",
+      date: "",
+      ticketUrl: "",
+      imageUrl: "",
+      genre: "Techno",
+    },
+  });
+
+  const onSubmit = async (data: GigData) => {
+    const res = await fetch("/api/gigs/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (res.ok) {
+      toast({ title: "Gig submitted", description: "Awaiting admin approval" });
+      form.reset();
+    } else {
+      toast({ title: "Submission failed", variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <UniversalHeader />
+      <div className="flex-1 container mx-auto px-4 pt-20 pb-8">
+        <Card className="max-w-2xl mx-auto">
+          <CardHeader>
+            <CardTitle>Submit a Gig</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Title</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Description</FormLabel>
+                      <FormControl>
+                        <Textarea {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="venue"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Venue</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="location"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Location</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="date"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Date</FormLabel>
+                      <FormControl>
+                        <Input type="datetime-local" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="ticketUrl"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Ticket URL</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="imageUrl"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Flyer Image URL</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="genre"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Genre</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Button type="submit" className="w-full">
+                  Submit Gig
+                </Button>
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/services/feedService.ts
+++ b/client/src/services/feedService.ts
@@ -369,6 +369,62 @@ class FeedService {
       category: 'guides',
       description: 'Synth news and production tips'
     },
+    {
+      url: 'https://romanmusictherapy.com/feed/',
+      name: 'Roman Music Therapy',
+      website: 'https://romanmusictherapy.com',
+      category: 'guides',
+      description: 'Music therapy insights and resources'
+    },
+    {
+      url: 'https://www.heartandharmony.com/feed/',
+      name: 'Heart and Harmony',
+      website: 'https://www.heartandharmony.com',
+      category: 'guides',
+      description: 'Music therapy blog and news'
+    },
+    {
+      url: 'https://musictherapyed.com/feed/',
+      name: 'Music Therapy Ed',
+      website: 'https://musictherapyed.com',
+      category: 'guides',
+      description: 'Music therapy education articles'
+    },
+    {
+      url: 'https://feeds.buzzsprout.com/2101894.rss',
+      name: 'The Music Therapy Podcast',
+      website: 'https://buzzsprout.com/2101894',
+      category: 'guides',
+      description: 'Music therapy podcast feed'
+    },
+    {
+      url: 'https://www.hypebot.com/feed',
+      name: 'Hypebot',
+      website: 'https://www.hypebot.com',
+      category: 'guides',
+      description: 'Music business tips and trends'
+    },
+    {
+      url: 'https://blog.airgigs.com/feed/',
+      name: 'AirGigs Blog',
+      website: 'https://blog.airgigs.com',
+      category: 'guides',
+      description: 'Advice for session musicians'
+    },
+    {
+      url: 'https://musictravelguide.net/feed/',
+      name: 'Music Travel Guide',
+      website: 'https://musictravelguide.net',
+      category: 'guides',
+      description: 'Travel tips for touring musicians'
+    },
+    {
+      url: 'https://www.musicianshealthcorner.com/blog/feed',
+      name: 'Musicians Health Corner',
+      website: 'https://www.musicianshealthcorner.com',
+      category: 'guides',
+      description: 'Health and wellness advice for musicians'
+    },
 
     // Gigs Category - India Events
     {
@@ -484,7 +540,7 @@ class FeedService {
         return [];
       }
 
-      const oneWeekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+      const twoWeeksAgo = Date.now() - 14 * 24 * 60 * 60 * 1000;
 
       return data.items
         .map((item: any) => {
@@ -507,7 +563,7 @@ class FeedService {
           } as FeedItem;
         })
         .filter(item => item.title && item.title !== 'Untitled')
-        .filter(item => new Date(item.pubDate).getTime() >= oneWeekAgo);
+        .filter(item => new Date(item.pubDate).getTime() >= twoWeeksAgo);
 
     } catch (error) {
       console.error(`Error fetching ${source.name}:`, error);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1350,7 +1350,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         genre: z.string(),
         subGenre: z.string().optional(),
       });
-      const parsed = schema.parse(requestData);
+      const parsed: any = schema.parse(requestData);
 
       const location = (parsed.location || '').toLowerCase();
       if (!location.includes('india') && !location.includes('bangalore')) {
@@ -1377,7 +1377,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       const { genre, subGenre, ...gigData } = parsed;
-      const gig = await storage.createGig(gigData);
+      const gig = await storage.createGig({ ...gigData, isActive: false });
       res.json(gig);
     } catch (error) {
       if (error instanceof z.ZodError) {


### PR DESCRIPTION
## Summary
- extend Guides RSS feeds with therapy and travel blogs
- extend feed recency filter to 2 weeks
- set submitted gigs inactive until approved
- add admin action to approve gigs
- create user Submit Gig page and route

## Testing
- `npm run check` *(fails: Property 'isAdmin' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68781d2572cc832996d84d097e84f802